### PR TITLE
 Refresh token management

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,3 +8,4 @@ POSTGRES_PASSWORD=password
 JWT_SECRET=a5B9kQ3vN2tJ1L0mW4hX7zC8pYdR6sF  # Cadena de 32 caracteres
 JWT_ISSUER=app-name # Identificador único de quien genera el token
 JWT_EXPIRE=604800   # Tiempo en segundos hasta que el token caduca
+JWT_REFRESH_EXPIRE= 1209600

--- a/backend/src/main/java/com/footalentgroup/configuration/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/footalentgroup/configuration/JwtAuthenticationFilter.java
@@ -1,9 +1,12 @@
 package com.footalentgroup.configuration;
 
+import com.footalentgroup.models.entities.UserEntity;
 import com.footalentgroup.models.enums.Role;
+import com.footalentgroup.repositories.UserRepository;
 import com.footalentgroup.services.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
@@ -23,37 +26,67 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Autowired
     private JwtService jwtService;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
+
         String token = jwtService.extractToken(request.getHeader(AUTHORIZATION));
 
-        if (request.getServletPath().contains("/auth")) {
+        if (request.getServletPath().contains("/auth") || token.isEmpty()) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        if (token.isEmpty()) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+        if (jwtService.isTokenExpired(token)) { // si el token expiro
 
-        if (jwtService.isTokenExpired(token)) {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized
-                response.getWriter().write("El token ha expirado");
-                return;
+            String refreshToken = extractRefreshTokenFromCookies(request);
+            if (refreshToken != null && !jwtService.isTokenExpired(refreshToken)) {
+                String email = jwtService.email(refreshToken);
+                UserEntity user = userRepository.findByEmail(email).orElse(null);
+
+                if (user != null) {
+                    //se genera un nuevo token de acceso
+                    String newAccessToken = jwtService.createToken(
+                            user.getEmail(),
+                            user.getPassword(),
+                            user.getRole().name()
+                    );
+                    response.setHeader("Nuevo-token-acceso", newAccessToken);
+
+                    GrantedAuthority authority = new SimpleGrantedAuthority(Role.PREFIX + jwtService.role(token));
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            user.getEmail(),
+                            token,
+                            List.of(authority)
+                    );
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+                }
+            } else {
+                String email = jwtService.email(token);
+                GrantedAuthority authority = new SimpleGrantedAuthority(Role.PREFIX + jwtService.role(token));
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        email,
+                        null,
+                        List.of(authority)
+                );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
+            filterChain.doFilter(request, response);
+    }
 
-            GrantedAuthority authority = new SimpleGrantedAuthority(Role.PREFIX + jwtService.role(token));
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    jwtService.email(token),
-                    token,
-                    List.of(authority)
-            );
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-
-
-        filterChain.doFilter(request, response);
+    private String extractRefreshTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName().equals("refresh_token")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/backend/src/main/java/com/footalentgroup/controllers/AuthController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/AuthController.java
@@ -28,24 +28,17 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping
-    public ResponseEntity<TokenResponseDto> register(@Valid @RequestBody UserRequestDto userDto) {
+    public ResponseEntity<TokenResponseDto> register(@Valid @RequestBody UserRequestDto userDto, HttpServletResponse response) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(this.authService.createUser(userDto.toEntity()));
+                .body(this.authService.createUser(userDto.toEntity(), response));
     }
 
     @PostMapping(LOGIN)
-    public ResponseEntity<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto loginDto) {
+    public ResponseEntity<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto loginDto, HttpServletResponse response) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(this.authService.login(loginDto));
+                .body(this.authService.login(loginDto, response));
     }
 
-    @PostMapping(REFRESHTOKEN)
-    public ResponseEntity<TokenResponseDto> refreshToken(HttpServletRequest request,
-                             HttpServletResponse response) throws IOException {
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(this.authService.refreshToken(request, response));
-    }
 }

--- a/backend/src/main/java/com/footalentgroup/controllers/AuthController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/AuthController.java
@@ -4,6 +4,8 @@ import com.footalentgroup.models.dtos.request.LoginRequestDto;
 import com.footalentgroup.models.dtos.request.UserRequestDto;
 import com.footalentgroup.models.dtos.response.TokenResponseDto;
 import com.footalentgroup.services.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,12 +15,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 @RestController
 @RequestMapping(AuthController.AUTH)
 @RequiredArgsConstructor
 public class AuthController {
     public static final String AUTH = "/auth";
     public static final String LOGIN = "/login";
+    public static final String REFRESHTOKEN = "/refreshtoken";
 
     private final AuthService authService;
 
@@ -34,5 +39,13 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(this.authService.login(loginDto));
+    }
+
+    @PostMapping(REFRESHTOKEN)
+    public ResponseEntity<TokenResponseDto> refreshToken(HttpServletRequest request,
+                             HttpServletResponse response) throws IOException {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(this.authService.refreshToken(request, response));
     }
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/TokenResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/TokenResponseDto.java
@@ -6,5 +6,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class TokenResponseDto {
+
     private String token;
+    private String refreshToken;
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/TokenResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/TokenResponseDto.java
@@ -8,5 +8,4 @@ import lombok.Data;
 public class TokenResponseDto {
 
     private String token;
-    private String refreshToken;
 }

--- a/backend/src/main/java/com/footalentgroup/services/AuthService.java
+++ b/backend/src/main/java/com/footalentgroup/services/AuthService.java
@@ -9,9 +9,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public interface AuthService {
-    public TokenResponseDto createUser(UserEntity userDto);
+    public TokenResponseDto createUser(UserEntity userDto, HttpServletResponse response);
 
-    public TokenResponseDto login(LoginRequestDto loginRequestDto);
+    public TokenResponseDto login(LoginRequestDto loginRequestDto, HttpServletResponse response);
 
-    public TokenResponseDto refreshToken(HttpServletRequest request,HttpServletResponse response) throws IOException;
+
 }

--- a/backend/src/main/java/com/footalentgroup/services/AuthService.java
+++ b/backend/src/main/java/com/footalentgroup/services/AuthService.java
@@ -3,9 +3,15 @@ package com.footalentgroup.services;
 import com.footalentgroup.models.dtos.request.LoginRequestDto;
 import com.footalentgroup.models.dtos.response.TokenResponseDto;
 import com.footalentgroup.models.entities.UserEntity;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 
 public interface AuthService {
     public TokenResponseDto createUser(UserEntity userDto);
 
     public TokenResponseDto login(LoginRequestDto loginRequestDto);
+
+    public TokenResponseDto refreshToken(HttpServletRequest request,HttpServletResponse response) throws IOException;
 }

--- a/backend/src/main/java/com/footalentgroup/services/JwtService.java
+++ b/backend/src/main/java/com/footalentgroup/services/JwtService.java
@@ -51,6 +51,7 @@ public class JwtService {
                 .withClaim(ROLE_CLAIM, role)
                 .sign(getAlgorithm());
     }
+
     public String refreshToken(String email, String name, String role) {
         return generateToken(email, name, role, this.refreshExpiration);
     }

--- a/backend/src/main/java/com/footalentgroup/services/JwtService.java
+++ b/backend/src/main/java/com/footalentgroup/services/JwtService.java
@@ -19,11 +19,13 @@ public class JwtService {
     private final String secret;
     private final String issuer;
     private final int expire;
+    private final int refreshExpiration;
 
-    public JwtService(@Value("${jwt.secret}") String secret, @Value("${jwt.issuer}") String issuer, @Value("${jwt.expire}") int expire) {
+    public JwtService(@Value("${jwt.secret}") String secret, @Value("${jwt.issuer}") String issuer, @Value("${jwt.expire}") int expire, @Value("${JWT_REFRESH_EXPIRE}") int refreshExpiration) {
         this.secret = secret;
         this.issuer = issuer;
         this.expire = expire;
+        this.refreshExpiration = refreshExpiration;
     }
 
     public String extractToken(String bearer) {
@@ -35,15 +37,22 @@ public class JwtService {
     }
 
     public String createToken(String email, String name, String role) {
+        return generateToken(email, name, role, this.expire);
+    }
+
+    public String generateToken(String email, String name, String role, long expirationTime) {
         return JWT.create()
                 .withIssuer(this.issuer)
                 .withIssuedAt(new Date())
                 .withNotBefore(new Date())
-                .withExpiresAt(new Date(System.currentTimeMillis() + this.expire * 1000L))
+                .withExpiresAt(new Date(System.currentTimeMillis() + expirationTime * 1000L))
                 .withClaim(EMAIL_CLAIM, email)
                 .withClaim(NAME_CLAIM, name)
                 .withClaim(ROLE_CLAIM, role)
                 .sign(getAlgorithm());
+    }
+    public String refreshToken(String email, String name, String role) {
+        return generateToken(email, name, role, this.refreshExpiration);
     }
 
     public String email(String authorization) {
@@ -76,6 +85,12 @@ public class JwtService {
             return Optional.empty();
         }
     }
+
+    public boolean isTokenExpired(String token) {
+        Optional<DecodedJWT> decodedJWT = verifyToken(token);
+        return decodedJWT.isEmpty() || decodedJWT.get().getExpiresAt().before(new Date());
+    }
+
 
     private Algorithm getAlgorithm() {
         return Algorithm.HMAC256(this.secret);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -19,6 +19,6 @@ spring.jpa.properties.hibernate.format_sql=true
 jwt.secret=${JWT_SECRET}
 jwt.issuer=${JWT_ISSUER}
 jwt.expire=${JWT_EXPIRE}
-
+jwt.refresh.token.expiration=${JWT_REFRESH_EXPIRE}
 ## Deployment
 server.port=8080


### PR DESCRIPTION
Added refresh_token as an cookie during login and registration. Implemented logic in the JwtAuthenticationFilter to check for token expiration and renew the JWT using a valid refresh token.  Included logic to send the new access token via response header (New-Access-Token).