### PR TITLE
feat(backend): restrict /musician-profile PUT to MUSICIAN role and add image file validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,7 @@ JWT_SECRET=a5B9kQ3vN2tJ1L0mW4hX7zC8pYdR6sF  # Cadena de 32 caracteres
 JWT_ISSUER=app-name # Identificador único de quien genera el token
 JWT_EXPIRE=604800   # Tiempo en segundos hasta que el token caduca
 JWT_REFRESH_EXPIRE= 1209600
+
+CLOUDINARY_CLOUD_NAME=CloudName
+CLOUDINARY_API_KEY=ApiKey
+CLOUDINARY_API_SECRET=ApiSecret

--- a/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
+++ b/backend/src/main/java/com/footalentgroup/configuration/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.footalentgroup.configuration;
 
 import com.footalentgroup.models.entities.UserEntity;
+import com.footalentgroup.models.enums.Role;
 import com.footalentgroup.repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -57,6 +58,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/musician-profile/*").permitAll()
+                        .requestMatchers(HttpMethod.PUT, "/musician-profile").hasRole(Role.MUSICIAN.name())
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianProfileRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianProfileRequestDto.java
@@ -1,5 +1,6 @@
 package com.footalentgroup.models.dtos.request;
 
+import com.footalentgroup.validators.ImageFile;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,7 +10,9 @@ public record MusicianProfileRequestDto(
         @NotBlank(message = "El nombre de artista/banda no puede estar vacío")
         String stageName,
 
+        @ImageFile
         MultipartFile photo,
+
         boolean deletePhoto,
 
         @NotBlank(message = "El genero no debe estar vacio")

--- a/backend/src/main/java/com/footalentgroup/validators/ImageFile.java
+++ b/backend/src/main/java/com/footalentgroup/validators/ImageFile.java
@@ -1,0 +1,18 @@
+package com.footalentgroup.validators;
+
+import com.footalentgroup.validators.impl.ImageFileValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ImageFileValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ImageFile {
+    String message() default "El archivo debe ser una imagen válida (jpg, jpeg, png, webp)";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/backend/src/main/java/com/footalentgroup/validators/impl/ImageFileValidator.java
+++ b/backend/src/main/java/com/footalentgroup/validators/impl/ImageFileValidator.java
@@ -1,0 +1,26 @@
+package com.footalentgroup.validators.impl;
+
+import com.footalentgroup.validators.ImageFile;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public class ImageFileValidator implements ConstraintValidator<ImageFile, MultipartFile> {
+
+    private static final List<String> ALLOWED_TYPES = List.of(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/webp"
+    );
+
+    @Override
+    public boolean isValid(MultipartFile file, ConstraintValidatorContext context) {
+        if (file == null || file.isEmpty()) {
+            return true;
+        }
+        return ALLOWED_TYPES.contains(file.getContentType());
+    }
+}


### PR DESCRIPTION
- Restricted access to PUT /musician-profile to users with MUSICIAN role
- Added custom @ImageFile validator for MultipartFile to only accept specific image formats (JPG, JPEG, PNG, WEBP)