### PR TITLE
Organizer: GET/POST/PUT endpoints & services

### DIFF
--- a/backend/src/main/java/com/footalentgroup/controllers/OrganizerProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/OrganizerProfileController.java
@@ -6,23 +6,40 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(OrganizerProfileController.ORGANIZERS)
 @RequiredArgsConstructor
 public class OrganizerProfileController {
     public static final String ORGANIZERS = "/organizers";
+    public static final String ID_ID = "/{id}";
 
     private final OrganizerService organizerService;
 
+    @GetMapping(ID_ID)
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> read(@PathVariable Long id) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(this.organizerService.read(id));
+    }
+
     @PostMapping(consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('ORGANIZER')")
     public ResponseEntity<?> create(@ModelAttribute @Valid OrganizerRequestDto organizerRequestDto) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(this.organizerService.create(organizerRequestDto));
+    }
+
+    @PutMapping(path = ID_ID, consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('ORGANIZER')")
+    public ResponseEntity<?> update(@PathVariable Long id, @ModelAttribute @Valid OrganizerRequestDto organizerRequestDto) {
+        organizerRequestDto.doDefault();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(this.organizerService.update(id, organizerRequestDto));
     }
 }

--- a/backend/src/main/java/com/footalentgroup/controllers/OrganizerProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/OrganizerProfileController.java
@@ -1,7 +1,13 @@
 package com.footalentgroup.controllers;
 
+import com.footalentgroup.models.dtos.request.OrganizerRequestDto;
 import com.footalentgroup.services.OrganizerService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +18,11 @@ public class OrganizerProfileController {
     public static final String ORGANIZERS = "/organizers";
 
     private final OrganizerService organizerService;
+
+    @PostMapping(consumes = "multipart/form-data")
+    public ResponseEntity<?> create(@ModelAttribute @Valid OrganizerRequestDto organizerRequestDto) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(this.organizerService.create(organizerRequestDto));
+    }
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/OrganizerMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/OrganizerMapper.java
@@ -1,0 +1,19 @@
+package com.footalentgroup.models.dtos.mapper;
+
+import com.footalentgroup.models.dtos.request.OrganizerRequestDto;
+import com.footalentgroup.models.dtos.response.OrganizerResponseDto;
+import com.footalentgroup.models.entities.OrganizerUserEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface OrganizerMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "user", ignore = true)
+    @Mapping(target = "image", ignore = true)
+    OrganizerUserEntity toEntity(OrganizerRequestDto dto);
+
+    @Mapping(source = "user.email", target = "email")
+    OrganizerResponseDto toResponse(OrganizerUserEntity user);
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/OrganizerMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/OrganizerMapper.java
@@ -5,6 +5,7 @@ import com.footalentgroup.models.dtos.response.OrganizerResponseDto;
 import com.footalentgroup.models.entities.OrganizerUserEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "spring")
 public interface OrganizerMapper {
@@ -12,8 +13,15 @@ public interface OrganizerMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "user", ignore = true)
     @Mapping(target = "image", ignore = true)
+    @Mapping(target = "imagePublicId", ignore = true)
     OrganizerUserEntity toEntity(OrganizerRequestDto dto);
 
     @Mapping(source = "user.email", target = "email")
     OrganizerResponseDto toResponse(OrganizerUserEntity user);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "user", ignore = true)
+    @Mapping(target = "image", ignore = true)
+    @Mapping(target = "imagePublicId", ignore = true)
+    void updateEntity(OrganizerRequestDto dto, @MappingTarget OrganizerUserEntity user);
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/OrganizerRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/OrganizerRequestDto.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Objects;
+
 @Data
 @Builder
 @AllArgsConstructor
@@ -27,4 +29,12 @@ public class OrganizerRequestDto {
     private String description;
 
     private MultipartFile image;
+
+    private Boolean deletedImage;
+
+    public void doDefault() {
+        if (Objects.isNull(deletedImage)) {
+            this.deletedImage = false;
+        }
+    }
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/OrganizerRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/OrganizerRequestDto.java
@@ -1,0 +1,30 @@
+package com.footalentgroup.models.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class OrganizerRequestDto {
+
+    @NotBlank(message = "El nombre no puede estar vacío.")
+    private String name;
+
+    @NotBlank(message = "El género no puede estar vacío.")
+    private String gender;
+
+    @NotBlank(message = "El país no puede estar vacío.")
+    private String country;
+
+    private String whatsapp;
+
+    private String website;
+
+    private String description;
+
+    private MultipartFile image;
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/OrganizerResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/OrganizerResponseDto.java
@@ -1,0 +1,20 @@
+package com.footalentgroup.models.dtos.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganizerResponseDto {
+    private Long id;
+    private String name;
+    private String gender;
+    private String country;
+    private String email;
+    private String whatsapp;
+    private String website;
+    private String description;
+    private String image;
+}

--- a/backend/src/main/java/com/footalentgroup/models/entities/OrganizerUserEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/OrganizerUserEntity.java
@@ -38,6 +38,9 @@ public class OrganizerUserEntity {
     @Column(nullable = true)
     private String image;
 
+    @Column(name = "image_public_id", nullable = true)
+    private String imagePublicId;
+
     @OneToOne
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private UserEntity user;

--- a/backend/src/main/java/com/footalentgroup/services/OrganizerService.java
+++ b/backend/src/main/java/com/footalentgroup/services/OrganizerService.java
@@ -1,4 +1,8 @@
 package com.footalentgroup.services;
 
+import com.footalentgroup.models.dtos.request.OrganizerRequestDto;
+import com.footalentgroup.models.dtos.response.OrganizerResponseDto;
+
 public interface OrganizerService {
+    OrganizerResponseDto create(OrganizerRequestDto organizerDto);
 }

--- a/backend/src/main/java/com/footalentgroup/services/OrganizerService.java
+++ b/backend/src/main/java/com/footalentgroup/services/OrganizerService.java
@@ -4,5 +4,7 @@ import com.footalentgroup.models.dtos.request.OrganizerRequestDto;
 import com.footalentgroup.models.dtos.response.OrganizerResponseDto;
 
 public interface OrganizerService {
+    OrganizerResponseDto read(Long id);
     OrganizerResponseDto create(OrganizerRequestDto organizerDto);
+    OrganizerResponseDto update(Long id, OrganizerRequestDto organizerDto);
 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/OrganizerServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/OrganizerServiceImpl.java
@@ -1,12 +1,61 @@
 package com.footalentgroup.services.impl;
 
+import com.footalentgroup.exceptions.ForbiddenException;
+import com.footalentgroup.exceptions.NotFoundException;
+import com.footalentgroup.models.dtos.mapper.OrganizerMapper;
+import com.footalentgroup.models.dtos.request.OrganizerRequestDto;
+import com.footalentgroup.models.dtos.response.OrganizerResponseDto;
+import com.footalentgroup.models.entities.OrganizerUserEntity;
+import com.footalentgroup.models.entities.UserEntity;
+import com.footalentgroup.models.enums.Role;
 import com.footalentgroup.repositories.OrganizerUserRepository;
+import com.footalentgroup.repositories.UserRepository;
+import com.footalentgroup.services.AuthenticatedUserService;
+import com.footalentgroup.services.CloudinaryService;
 import com.footalentgroup.services.OrganizerService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class OrganizerServiceImpl implements OrganizerService {
-    private final OrganizerUserRepository organizerUserRepository;
+    private final UserRepository userRepository;
+    private final OrganizerUserRepository organizerRepository;
+    private final AuthenticatedUserService authenticatedUserService;
+    private final CloudinaryService cloudinaryService;
+    private final OrganizerMapper organizerMapper;
+
+    @Override
+    @Transactional
+    public OrganizerResponseDto create(OrganizerRequestDto organizerDto) {
+        OrganizerUserEntity organizer = this.organizerMapper.toEntity(organizerDto);
+        organizer.setUser(getRequestUser());
+        organizer.setImage(saveImage(organizerDto.getImage()));
+
+        return this.organizerMapper.toResponse(this.organizerRepository.save(organizer));
+    }
+
+    private UserEntity getRequestUser() {
+        String email = this.authenticatedUserService.getAuthenticatedUsername();
+
+        UserEntity user = this.userRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("Organizador no encontrado: " + email));
+
+        if (!user.getRole().equals(Role.ORGANIZER)) {
+            throw new ForbiddenException("El usuario no tiene permisos de organizador");
+        }
+
+        return user;
+    }
+
+    private String saveImage(MultipartFile file) {
+        if (file != null && !file.isEmpty()) {
+            return this.cloudinaryService.uploadImage(file).get("secure_url").toString();
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
- Se agregó el endpoint `GET` para obtener los datos del organizador por ID.
- Se agregó el endpoint `POST` para registrar los datos del organizador.
- Se agregó el endpoint `PUT` para actualizar los datos del organizador.
- Se implementó el `mapper` para transformar entre entidad y DTO.
- Se implementó el método `read`, `create` y `update` en el servicio, encargado de la lógica de la entidad `OrganizerUser`.

## Prueba en Postman

### Petición GET

![get-organizers](https://github.com/user-attachments/assets/f00e97ac-2b8d-4787-a2c8-3edc79296db8)

### Petición POST

![post-organizers](https://github.com/user-attachments/assets/ff22ae22-9828-4cf1-bec7-3b136fbaab51)

![post-organizers-response](https://github.com/user-attachments/assets/e8ab6fd4-6a3c-4050-a280-4aae1c9bbc74)

### Petición PUT

![put-organizers](https://github.com/user-attachments/assets/9bc5b548-75c0-4dfe-85c7-a391e7906737)

![put-organizers-response](https://github.com/user-attachments/assets/3174e8b5-3133-4ed5-ab95-c0a420ebc073)
