### PR TITLE
Musician: Endpoint GET para filtrar por nombre de artista/banda o género con paginado  #53 HU-O4  

### DIFF
--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,4 +40,16 @@ public class MusicianProfileController {
                 .body(new ApiResponse<>("Perfil de musico Actualizado"));
     }
 
+    @Operation(summary = "Buscar musicos por nombre y genero (paginado)")
+    @GetMapping("/search")
+    public ResponseEntity<?> searchMusicians(
+            @RequestParam(required = false, defaultValue = "") String stageName,
+            @RequestParam(required = false, defaultValue = "") String genre,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "3" )@Min(1) int size
+            ){
+        return ResponseEntity
+                .ok()
+                .body(this.musicService.searchMusicians(stageName, genre, page, size));
+    }
 }

--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
@@ -1,6 +1,7 @@
 package com.footalentgroup.controllers;
 
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
+import com.footalentgroup.models.dtos.request.MusicianSearchRequestDTO;
 import com.footalentgroup.models.dtos.response.ApiResponse;
 import com.footalentgroup.services.MusicianProfileService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,7 +11,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -42,14 +45,10 @@ public class MusicianProfileController {
 
     @Operation(summary = "Buscar musicos por nombre y genero (paginado)")
     @GetMapping("/search")
-    public ResponseEntity<?> searchMusicians(
-            @RequestParam(required = false, defaultValue = "") String stageName,
-            @RequestParam(required = false, defaultValue = "") String genre,
-            @RequestParam(defaultValue = "0") @Min(0) int page,
-            @RequestParam(defaultValue = "3" )@Min(1) int size
-            ){
+    public ResponseEntity<?> searchMusicians(@ParameterObject @ModelAttribute @Valid MusicianSearchRequestDTO requestDto){
+
         return ResponseEntity
                 .ok()
-                .body(this.musicService.searchMusicians(stageName, genre, page, size));
+                .body(this.musicService.searchMusicians(requestDto));
     }
 }

--- a/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/MusicianProfileController.java
@@ -45,7 +45,7 @@ public class MusicianProfileController {
 
     @Operation(summary = "Buscar musicos por nombre y genero (paginado)")
     @GetMapping("/search")
-    public ResponseEntity<?> searchMusicians(@ParameterObject @ModelAttribute @Valid MusicianSearchRequestDTO requestDto){
+    public ResponseEntity<?> searchMusicians(@ParameterObject @Valid MusicianSearchRequestDTO requestDto){
 
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianSearchRequestDTO.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianSearchRequestDTO.java
@@ -1,0 +1,38 @@
+package com.footalentgroup.models.dtos.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MusicianSearchRequestDTO {
+
+    @Schema(example = "")
+    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ ]*$", message = "El nombre del artista solo puede contener letras y espacios")
+    private String stageName;
+
+    @Schema(example = "")
+    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ ]*$", message = "El género musical solo puede contener letras y espacios")
+    private String genre;
+
+    @Schema(defaultValue = "0")
+    @Min(value = 0, message = "La pagina no puede ser menor que 0")
+    private int page;
+
+    @Schema(defaultValue = "3")
+    @Min(value = 1, message = "El tamaño debe ser mayor o igual a 1")
+    private int size;
+
+    public MusicianSearchRequestDTO() {
+        this.stageName = "";
+        this.genre = "";
+        this.page = 0;
+        this.size = 3;
+    }
+}
+
+

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianSearchRequestDTO.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianSearchRequestDTO.java
@@ -12,11 +12,13 @@ import lombok.Data;
 public class MusicianSearchRequestDTO {
 
     @Schema(example = "")
-    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ0-9 ./\\-_'&!#,+()?]*$", message = "El nombre del artista solo puede contener letras y espacios (se permiten ., /, - y ')")
+    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ0-9 ./'&\\-/]*$",
+            message = "El nombre del artista solo puede contener letras y espacios (se permiten ., /, -, ' y &)")
     private String stageName;
 
     @Schema(example = "")
-    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ0-9 ./\\-_'&!#,+()?]*$", message = "El género musical solo puede contener letras y espacios (se permiten ., /, - y ')")
+    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ0-9 ./'&\\-/]*$",
+            message = "El género musical solo puede contener letras, números y espacios (se permiten ., /, -, ' y &)")
     private String genre;
 
     @Schema(defaultValue = "0")

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianSearchRequestDTO.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/MusicianSearchRequestDTO.java
@@ -12,11 +12,11 @@ import lombok.Data;
 public class MusicianSearchRequestDTO {
 
     @Schema(example = "")
-    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ ]*$", message = "El nombre del artista solo puede contener letras y espacios")
+    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ0-9 ./\\-_'&!#,+()?]*$", message = "El nombre del artista solo puede contener letras y espacios (se permiten ., /, - y ')")
     private String stageName;
 
     @Schema(example = "")
-    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ ]*$", message = "El género musical solo puede contener letras y espacios")
+    @Pattern(regexp = "^[a-zA-ZáéíóúÁÉÍÓÚñÑ0-9 ./\\-_'&!#,+()?]*$", message = "El género musical solo puede contener letras y espacios (se permiten ., /, - y ')")
     private String genre;
 
     @Schema(defaultValue = "0")

--- a/backend/src/main/java/com/footalentgroup/repositories/MusicianProfileRepository.java
+++ b/backend/src/main/java/com/footalentgroup/repositories/MusicianProfileRepository.java
@@ -1,7 +1,10 @@
 package com.footalentgroup.repositories;
 
 
+import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
 import com.footalentgroup.models.entities.MusicianProfileEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,5 +12,5 @@ import java.util.Optional;
 public interface MusicianProfileRepository extends JpaRepository<MusicianProfileEntity, Long> {
 
     Optional<MusicianProfileEntity> findByUserEmail(String email);
-
+    Page<MusicianProfileResponseDto> findByStageNameContainingIgnoreCaseAndGenreContainingIgnoreCase(String stageName, String genre, Pageable pageable);
 }

--- a/backend/src/main/java/com/footalentgroup/services/MusicianProfileService.java
+++ b/backend/src/main/java/com/footalentgroup/services/MusicianProfileService.java
@@ -3,6 +3,7 @@ package com.footalentgroup.services;
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
 import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
 import com.footalentgroup.models.entities.UserEntity;
+import org.springframework.data.domain.Page;
 
 public interface MusicianProfileService {
 
@@ -12,4 +13,5 @@ public interface MusicianProfileService {
 
     void updateProfile(MusicianProfileRequestDto requestDto);
 
+    Page<MusicianProfileResponseDto> searchMusicians(String stageName, String genre, int page, int size);
 }

--- a/backend/src/main/java/com/footalentgroup/services/MusicianProfileService.java
+++ b/backend/src/main/java/com/footalentgroup/services/MusicianProfileService.java
@@ -1,6 +1,7 @@
 package com.footalentgroup.services;
 
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
+import com.footalentgroup.models.dtos.request.MusicianSearchRequestDTO;
 import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
 import com.footalentgroup.models.entities.UserEntity;
 import org.springframework.data.domain.Page;
@@ -13,5 +14,5 @@ public interface MusicianProfileService {
 
     void updateProfile(MusicianProfileRequestDto requestDto);
 
-    Page<MusicianProfileResponseDto> searchMusicians(String stageName, String genre, int page, int size);
+    Page<MusicianProfileResponseDto> searchMusicians(MusicianSearchRequestDTO requestDTO);
 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/MusicianProfileServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/MusicianProfileServiceImpl.java
@@ -71,7 +71,7 @@ public class MusicianProfileServiceImpl implements MusicianProfileService {
 
     @Override
     public Page<MusicianProfileResponseDto> searchMusicians(MusicianSearchRequestDTO requestDTO) {
-        //Orden por nombre de forma ascendente
+        //Ordenamiento por nombre de forma ascendente
         Pageable pageable= PageRequest.of(requestDTO.getPage(), requestDTO.getSize(), Sort.by(Sort.Order.asc("stageName")));
         return  musicianRepository.findByStageNameContainingIgnoreCaseAndGenreContainingIgnoreCase(requestDTO.getStageName(),requestDTO.getGenre() ,pageable);
     }

--- a/backend/src/main/java/com/footalentgroup/services/impl/MusicianProfileServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/MusicianProfileServiceImpl.java
@@ -11,6 +11,10 @@ import com.footalentgroup.services.AuthenticatedUserService;
 import com.footalentgroup.services.CloudinaryService;
 import com.footalentgroup.services.MusicianProfileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -62,5 +66,12 @@ public class MusicianProfileServiceImpl implements MusicianProfileService {
         }
 
         musicianRepository.save(music);
+    }
+
+    @Override
+    public Page<MusicianProfileResponseDto> searchMusicians(String stageName, String genre, int page, int size) {
+        //Orden por nombre de forma ascendente
+        Pageable pageable= PageRequest.of(page, size, Sort.by(Sort.Order.asc("stageName")));
+        return  musicianRepository.findByStageNameContainingIgnoreCaseAndGenreContainingIgnoreCase(stageName,genre,pageable);
     }
 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/MusicianProfileServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/MusicianProfileServiceImpl.java
@@ -3,6 +3,7 @@ package com.footalentgroup.services.impl;
 import com.footalentgroup.exceptions.MusicianProfileNotFoundException;
 import com.footalentgroup.models.dtos.mapper.MusicProfileMapper;
 import com.footalentgroup.models.dtos.request.MusicianProfileRequestDto;
+import com.footalentgroup.models.dtos.request.MusicianSearchRequestDTO;
 import com.footalentgroup.models.dtos.response.MusicianProfileResponseDto;
 import com.footalentgroup.models.entities.MusicianProfileEntity;
 import com.footalentgroup.models.entities.UserEntity;
@@ -69,9 +70,9 @@ public class MusicianProfileServiceImpl implements MusicianProfileService {
     }
 
     @Override
-    public Page<MusicianProfileResponseDto> searchMusicians(String stageName, String genre, int page, int size) {
+    public Page<MusicianProfileResponseDto> searchMusicians(MusicianSearchRequestDTO requestDTO) {
         //Orden por nombre de forma ascendente
-        Pageable pageable= PageRequest.of(page, size, Sort.by(Sort.Order.asc("stageName")));
-        return  musicianRepository.findByStageNameContainingIgnoreCaseAndGenreContainingIgnoreCase(stageName,genre,pageable);
+        Pageable pageable= PageRequest.of(requestDTO.getPage(), requestDTO.getSize(), Sort.by(Sort.Order.asc("stageName")));
+        return  musicianRepository.findByStageNameContainingIgnoreCaseAndGenreContainingIgnoreCase(requestDTO.getStageName(),requestDTO.getGenre() ,pageable);
     }
 }


### PR DESCRIPTION
Se añadió un endpoint GET para obtener una lista paginada de artistas, con la opción de filtrar por nombre de artista/banda o género musical.
Para validar los datos de entrada, se implementó el uso de un MusicianSearchRequestDTO, que contiene las validaciones necesarias para asegurar que los parámetros de búsqueda sigan el formato adecuado.
Además, se definieron valores predeterminados para los parámetros de paginado.