### PR TITLE
Implement create and update functionality for events

### DIFF
--- a/backend/src/main/java/com/footalentgroup/controllers/EventController.java
+++ b/backend/src/main/java/com/footalentgroup/controllers/EventController.java
@@ -1,7 +1,12 @@
 package com.footalentgroup.controllers;
 
+import com.footalentgroup.models.dtos.request.EventRequestDto;
 import com.footalentgroup.services.impl.EventServiceImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -9,6 +14,33 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class EventController {
     public static final String EVENTS = "/events";
+    public static final String ID_ID = "/{id}";
 
     private final EventServiceImpl eventService;
+
+    @GetMapping(ID_ID)
+    public ResponseEntity<?> read(@PathVariable Long id) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(this.eventService.read(id));
+    }
+
+    @PostMapping(consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('MUSICIAN')")
+    public ResponseEntity<?> create(@ModelAttribute @Valid EventRequestDto eventDto) {
+        eventDto.doDefault();
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(this.eventService.create(eventDto));
+    }
+
+    @PutMapping(value = ID_ID, consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('MUSICIAN')")
+    public ResponseEntity<?> update(@PathVariable Long id, @ModelAttribute @Valid EventRequestDto eventDto) {
+        eventDto.doDefault();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(this.eventService.update(id, eventDto));
+    }
 }

--- a/backend/src/main/java/com/footalentgroup/models/dtos/mapper/EventMapper.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/mapper/EventMapper.java
@@ -1,0 +1,27 @@
+package com.footalentgroup.models.dtos.mapper;
+
+import com.footalentgroup.models.dtos.request.EventRequestDto;
+import com.footalentgroup.models.dtos.response.EventResponseDto;
+import com.footalentgroup.models.entities.EventEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface EventMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "image", ignore = true)
+    @Mapping(target = "imagePublicId", ignore = true)
+    @Mapping(target = "musician", ignore = true)
+    EventEntity toEntity(EventRequestDto dto);
+
+    @Mapping(target = "musicianId", source = "musician.id")
+    EventResponseDto toDto(EventEntity entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "image", ignore = true)
+    @Mapping(target = "imagePublicId", ignore = true)
+    @Mapping(target = "musician", ignore = true)
+    void updateEntity(EventRequestDto dto, @MappingTarget EventEntity entity);
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/request/EventRequestDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/request/EventRequestDto.java
@@ -1,0 +1,85 @@
+package com.footalentgroup.models.dtos.request;
+
+import com.footalentgroup.models.enums.EventTicket;
+import com.footalentgroup.models.enums.EventType;
+import com.footalentgroup.validators.ImageFile;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class EventRequestDto {
+
+    @NotBlank(message = "El nombre del evento no puede estar vacío.")
+    private String name;
+
+    @NotBlank(message = "La categoría del evento no puede estar vacía.")
+    private String category;
+
+    @NotNull(message = "El tipo de evento es obligatorio.")
+    private EventType type;
+
+    @NotBlank(message = "La fecha del evento es obligatoria.")
+    private String dateString;  // Stores the raw date string from the request
+    private LocalDate date;     // Stores the parsed and validated LocalDate object
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+    @NotNull(message = "La hora de inicio es obligatoria.")
+    private LocalTime startTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+    @NotNull(message = "La hora de finalización es obligatoria.")
+    private LocalTime endTime;
+
+    @NotBlank(message = "La ubicación del evento no puede estar vacía.")
+    private String location;
+
+    @NotBlank(message = "La descripción del evento no puede estar vacía.")
+    private String description;
+
+    @ImageFile
+    private MultipartFile image;
+
+    private Boolean deleteImage;
+
+    private EventTicket ticket;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "El precio debe ser mayor a cero.")
+    private BigDecimal price;
+
+    private Boolean active;
+
+    @NotNull(message = "El ID del músico es obligatorio.")
+    private Long musicianId;
+
+    public void doDefault() {
+        if (dateString != null && !dateString.isEmpty()) {
+            date = LocalDate.parse(dateString, DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        }
+
+        if (Objects.isNull(deleteImage)) {
+            deleteImage = false;
+        }
+
+        if (Objects.isNull(ticket)) {
+            ticket = EventTicket.FreeEvent;
+        }
+
+        if (Objects.isNull(price)) {
+            price = BigDecimal.ZERO;
+        }
+    }
+}

--- a/backend/src/main/java/com/footalentgroup/models/dtos/response/EventResponseDto.java
+++ b/backend/src/main/java/com/footalentgroup/models/dtos/response/EventResponseDto.java
@@ -1,0 +1,35 @@
+package com.footalentgroup.models.dtos.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.footalentgroup.models.enums.EventTicket;
+import com.footalentgroup.models.enums.EventType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EventResponseDto {
+    private Long id;
+    private String name;
+    private String category;
+    private EventType type;
+    @JsonFormat(pattern = "dd/MM/yyyy")
+    private LocalDate date;
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime startTime;
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime endTime;
+    private String location;
+    private String description;
+    private String image;
+    private EventTicket ticket;
+    private BigDecimal price;
+    private Boolean active;
+    private Long musicianId;
+}

--- a/backend/src/main/java/com/footalentgroup/models/entities/EventEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/EventEntity.java
@@ -1,5 +1,7 @@
 package com.footalentgroup.models.entities;
 
+import com.footalentgroup.models.enums.EventTicket;
+import com.footalentgroup.models.enums.EventType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,7 +9,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.type.TrueFalseConverter;
 
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Data
 @Builder
@@ -27,8 +31,20 @@ public class EventEntity {
     private String category;
 
     @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime date;
+    @Enumerated(EnumType.STRING)
+    private EventType type;
+
+    @Column(nullable = false)
+    @Temporal(TemporalType.DATE)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    @Temporal(TemporalType.TIME)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    @Temporal(TemporalType.TIME)
+    private LocalTime endTime;
 
     @Column(nullable = false)
     private String location;
@@ -39,6 +55,19 @@ public class EventEntity {
     @Column(nullable = true)
     private String image;
 
+    @Column(nullable = true)
+    private String imagePublicId;
+
+    @Enumerated(EnumType.STRING)
+    private EventTicket ticket;
+
+    @Column(nullable = true)
+    private BigDecimal price;
+
     @Convert(converter = TrueFalseConverter.class)
     private Boolean active;
+
+    @ManyToOne
+    @JoinColumn(name = "musician_id", nullable = false)
+    private MusicianProfileEntity musician;
 }

--- a/backend/src/main/java/com/footalentgroup/models/entities/UserEntity.java
+++ b/backend/src/main/java/com/footalentgroup/models/entities/UserEntity.java
@@ -29,7 +29,4 @@ public class UserEntity {
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
-    private MusicianProfileEntity musicProfile;
 }

--- a/backend/src/main/java/com/footalentgroup/models/enums/EventTicket.java
+++ b/backend/src/main/java/com/footalentgroup/models/enums/EventTicket.java
@@ -1,0 +1,6 @@
+package com.footalentgroup.models.enums;
+
+public enum EventTicket {
+    TicketedEvent,
+    FreeEvent
+}

--- a/backend/src/main/java/com/footalentgroup/models/enums/EventType.java
+++ b/backend/src/main/java/com/footalentgroup/models/enums/EventType.java
@@ -1,0 +1,6 @@
+package com.footalentgroup.models.enums;
+
+public enum EventType {
+    Single,
+    Recurring;
+}

--- a/backend/src/main/java/com/footalentgroup/services/EventService.java
+++ b/backend/src/main/java/com/footalentgroup/services/EventService.java
@@ -1,4 +1,10 @@
 package com.footalentgroup.services;
 
+import com.footalentgroup.models.dtos.request.EventRequestDto;
+import com.footalentgroup.models.dtos.response.EventResponseDto;
+
 public interface EventService {
+    EventResponseDto read(Long id);
+    EventResponseDto create(EventRequestDto eventDto);
+    EventResponseDto update(Long id, EventRequestDto eventDto);
 }

--- a/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
+++ b/backend/src/main/java/com/footalentgroup/services/impl/EventServiceImpl.java
@@ -1,12 +1,80 @@
 package com.footalentgroup.services.impl;
 
+import com.footalentgroup.exceptions.NotFoundException;
+import com.footalentgroup.models.dtos.mapper.EventMapper;
+import com.footalentgroup.models.dtos.request.EventRequestDto;
+import com.footalentgroup.models.dtos.response.EventResponseDto;
+import com.footalentgroup.models.entities.EventEntity;
+import com.footalentgroup.models.entities.MusicianProfileEntity;
 import com.footalentgroup.repositories.EventRepository;
+import com.footalentgroup.repositories.MusicianProfileRepository;
+import com.footalentgroup.services.CloudinaryService;
 import com.footalentgroup.services.EventService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class EventServiceImpl implements EventService {
     private final EventRepository eventRepository;
+    private final MusicianProfileRepository musicianRepository;
+    private final CloudinaryService cloudinaryService;
+    private final EventMapper eventMapper;
+
+    @Override
+    public EventResponseDto read(Long id) {
+        EventEntity event = this.eventRepository
+                .findById(id)
+                .orElseThrow(() -> new NotFoundException("Evento no encontrado: " + id));
+        return this.eventMapper.toDto(event);
+    }
+
+    @Override
+    @Transactional
+    public EventResponseDto create(EventRequestDto eventDto) {
+        MusicianProfileEntity musician = this.musicianRepository
+                .findById(eventDto.getMusicianId())
+                .orElseThrow(() -> new NotFoundException("Musico/Banda no encontrado"));
+
+        EventEntity event = this.eventMapper.toEntity(eventDto);
+        event.setMusician(musician);
+        saveImage(eventDto.getImage(), event);
+
+        return this.eventMapper.toDto(this.eventRepository.save(event));
+    }
+
+    @Override
+    @Transactional
+    public EventResponseDto update(Long id, EventRequestDto eventDto) {
+        EventEntity event = this.eventRepository
+                .findById(id)
+                .orElseThrow(() -> new NotFoundException("Evento no encontrado: " + id));
+
+        this.eventMapper.updateEntity(eventDto, event);
+        updateImage(eventDto.getImage(), event, eventDto.getDeleteImage());
+
+        return this.eventMapper.toDto(this.eventRepository.save(event));
+    }
+
+    private void saveImage(MultipartFile file, EventEntity event) {
+        if (file != null && !file.isEmpty()) {
+            Map<String, Object> image = cloudinaryService.uploadImage(file);
+            event.setImage(image.get("secure_url").toString());
+            event.setImagePublicId(image.get("public_id").toString());
+        }
+    }
+
+    private void updateImage(MultipartFile file, EventEntity event, Boolean deleteImage) {
+        if (deleteImage && event.getImagePublicId() != null && !event.getImagePublicId().isEmpty()) {
+            cloudinaryService.deleteImage(event.getImagePublicId());
+            event.setImage(null);
+            event.setImagePublicId(null);
+        }
+
+        saveImage(file, event);
+    }
 }


### PR DESCRIPTION
- Se agregó el endpoint `GET` para obtener los datos del evento por ID.
- Se agregó el endpoint `POST` para registrar los datos del evento.
- Se agregó el endpoint `PUT` para actualizar los datos del evento
- Se implementó el mapper para transformar entre entidad y DTO..
- Se implementó el método `read`, `create` y `update` en el servicio, encargado de la lógica de la entidad `EventEntity`.

## Postman

### Petición POST

![event-post](https://github.com/user-attachments/assets/b8b322eb-d26b-429a-9a83-370ed5fa3590)

### Petición PUT

![event-put](https://github.com/user-attachments/assets/605acb1a-28c9-43d5-9782-15674c8d42c9)

### Petición GET

![event-get](https://github.com/user-attachments/assets/5a6fbfb0-6f1f-49cb-a961-03048b925b11)